### PR TITLE
Add url normalization to generator command.

### DIFF
--- a/k
+++ b/k
@@ -2015,12 +2015,20 @@ end
 PRIVATE_METHODS_AFTER_COMMANDS = private_methods - PRIVATE_METHODS_BEFORE_COMMANDS
 
 def verify_inside_context_repository!
+  context_repo_value = K_CONTEXT.fetch("repository").delete_suffix(".git")
+  current_repo_value = `git remote get-url origin`.strip.delete_suffix(".git")
 
-  context_repo = URI K_CONTEXT.fetch("repository").delete_suffix(".git")
-  current_repo = URI `git remote get-url origin`.strip.delete_suffix(".git")
-
-  unless context_repo.path == current_repo.path
+  unless normalized_git_url(current_repo_value).path == normalized_git_url(context_repo_value).path
     abort "Error: this command must be run from a clone of the context repository (#{context_repo})"
+  end
+end
+
+def normalized_git_url(url)
+  case url
+  when /^git@/ then URI "https://" + url[4..].sub(":", "/").delete_suffix(".git") # Convert SSH URL to HTTPS URL
+  when /^https:\/\// then URI url.delete_suffix(".git") # Remove .git suffix from HTTPS URL
+  else
+    abort "Error: url not supported (#{url})"
   end
 end
 


### PR DESCRIPTION
The `generate` command fails if the local stack repo has been set up with ssh urls instead of https urls.

### Steps to reproduce

1) **Set up a new local repo for `reclaim-the-stack` setting its origin to a ssh url**
e.g. `git remote add origin git@github.com:your-user/your-stack.git`)
1) **Create a new `k` context**
here, `k` will error if we try to insert a ssh url, so we _may_ add `https://github.com/your-user/your-stack.git` instead, to pass this step). 
However:
1) **Run `k generate [any args]`**
A parsing error like: `bad URI(is not URI?): "git@github.com:your-user/your-stack.git" (URI::InvalidURIError)` is raised.

PR patches step 3 by comparing a 'normalized' version of the repo path instead.
If this is needed, there may be more places where it can be added - e.g. during setup of the `k` context.

👍 / 👎 

