### PR TITLE
Support creating and editing secrets in multiple namespaces

### DIFF
--- a/k
+++ b/k
@@ -178,12 +178,12 @@ def print_commands
   puts "k rollback <application>" + gray(" show prompt to rollback an application")
   puts "k run <application> <command>" + gray(" run a command using a one off pod")
   puts "k scale <application> <deployment>:<replicas>" + gray(" scale a deployment in an application")
-  puts "k secrets [<specific-secret>]" + gray(" lists secrets including usage details")
-  puts "k secrets:create <secret-name>" + gray(" create a new secret")
-  puts "k secrets:edit <secret-name>" + gray(" edit a secret")
-  puts "k secrets:get <secret-name> <key>" + gray(" get a single secret value")
-  puts "k secrets:set <secret-name> <key>=<value> [<key2>=<value2> ...]" + gray(" set new secret values")
-  puts "k secrets:unset <secret-name> <key> [<key2> ...]" + gray(" unset / delete secret values")
+  puts "k secrets [namespace:][<specific-secret>]" + gray(" lists secrets including usage details")
+  puts "k secrets:create [namespace:]<secret-name>" + gray(" create a new secret")
+  puts "k secrets:edit [namespace:]<secret-name>" + gray(" edit a secret")
+  puts "k secrets:get [namespace:]<secret-name> <key>" + gray(" get a single secret value")
+  puts "k secrets:set [namespace:]<secret-name> <key>=<value> [<key2>=<value2> ...]" + gray(" set new secret values")
+  puts "k secrets:unset [namespace:]<secret-name> <key> [<key2> ...]" + gray(" unset / delete secret values")
   puts "k update" + gray(" update k to the latest version")
   puts ""
   puts "DEBUGGING COMMANDS:"
@@ -1671,7 +1671,11 @@ def scale
 end
 
 def secrets
-  specific_secret = ARGV.delete_at(0)
+  namespace, specific_secret = ARGV.delete_at(0)&.split(":")
+  unless specific_secret
+    specific_secret = namespace
+    namespace = "default"
+  end
 
   in_argo_repo do
     application_secrets = Dir.glob("applications/*/values.yaml").each_with_object({}) do |path, hash|
@@ -1700,6 +1704,7 @@ def secrets
         next unless YAML.load_file(secret_path).fetch("spec").fetch("template")["type"] == "opaque"
 
         secret = File.basename(secret_path, ".yaml")
+        secret = secret.sub(/__/, ":")
         puts bold(secret)
         application_secrets[secret]&.each do |application|
           puts gray("  #{application}")
@@ -1708,23 +1713,30 @@ def secrets
       end
     end
 
-    puts "Use k secrets:edit #{specific_secret || '<secret-name>'} to edit"
+    optional_namespace = namespace == "default" ? "" : "#{namespace}:"
+    optional_namespace = "[namespace:]" unless specific_secret
+    puts "Use k secrets:edit #{optional_namespace}#{specific_secret || '<secret-name>'} to edit"
   end
 end
 
 def secrets_edit
-  shared_secret = ARGV.delete_at(0)
-  abort "Must pass name of secret, eg. k secrets:edit <shared-secret-name>" unless shared_secret
+  namespace, shared_secret = ARGV.delete_at(0)&.split(":")
+  unless shared_secret
+    shared_secret = namespace
+    namespace = "default"
+  end
+
+  abort "Must pass name of secret, eg. k secrets:edit [namespace:]<shared-secret-name>" unless shared_secret
   abort "Missing $EDITOR environment variable, eg: export EDITOR='code --wait --new-window'" unless ENV.key?("EDITOR")
 
   in_argo_repo do
     require "base64"
 
-    original_secret = YAML.safe_load read_kubectl("get secret #{shared_secret} -o yaml")
+    original_secret = YAML.safe_load read_kubectl("get secret #{shared_secret} --namespace #{namespace} -o yaml")
     original_env = original_secret.fetch("data").transform_values(&Base64.method(:strict_decode64))
 
     # Write temporary file and launch editor
-    tmp_file = "/#{Dir.tmpdir}/#{shared_secret}.yaml"
+    tmp_file = "/#{Dir.tmpdir}/#{namespace_prefix(namespace)}#{shared_secret}.yaml"
     File.write tmp_file, original_env.to_yaml.delete_prefix("---\n")
     system "#{ENV.fetch('EDITOR')} #{tmp_file}"
 
@@ -1740,7 +1752,7 @@ def secrets_edit
     original_secret["data"] = data
 
     File.write(tmp_file, original_secret.to_yaml)
-    kubeseal tmp_file, "applications/shared-secrets/#{shared_secret}.yaml"
+    kubeseal tmp_file, "applications/shared-secrets/#{namespace_prefix(namespace)}#{shared_secret}.yaml"
     File.delete tmp_file
 
     changed_variables = new_env.keys.select do |name|
@@ -1749,7 +1761,7 @@ def secrets_edit
     added_variables = new_env.keys - original_env.keys
     deleted_variables = original_env.keys - new_env.keys
 
-    commit_message = "shared-secrets: edited #{shared_secret}\n\n"
+    commit_message = "shared-secrets: edited #{shared_secret} in namespace #{namespace}\n\n"
     commit_message << "Changed: #{changed_variables.join(' ')}\n" unless changed_variables.empty?
     commit_message << "Added: #{added_variables.join(' ')}\n" unless added_variables.empty?
     commit_message << "Deleted: #{deleted_variables.join(' ')}\n" unless deleted_variables.empty?
@@ -1762,19 +1774,24 @@ def secrets_edit
 end
 
 def secrets_get
-  if ARGV.length != 2
-    puts "Usage: k secrets:get <secret-name> <key>"
+  namespace, shared_secret = ARGV.delete_at(0)&.split(":")
+  key = ARGV.delete_at(0)
+  unless shared_secret
+    shared_secret = namespace
+    namespace = "default"
+  end
+
+  unless shared_secret && key
+    puts "Usage: k secrets:get [namespace:]<secret-name> <key>"
     exit
   end
 
-  shared_secret = ARGV.delete_at(0)
-  key = ARGV.delete_at(0)
-
   in_argo_repo do
-    secret_path = "applications/shared-secrets/#{shared_secret}.yaml"
+    secret_path = "applications/shared-secrets/#{namespace_prefix(namespace)}#{shared_secret}.yaml"
     abort "No shared secret found at '#{secret_path}'" unless File.exist?(secret_path)
 
-    kubernetes_secret = YAML.safe_load read_kubectl("get secret #{shared_secret} -o yaml")
+    namespace_option = namespace == "default" ? "" : "--namespace #{namespace}"
+    kubernetes_secret = YAML.safe_load read_kubectl("get secret #{shared_secret} -o yaml #{namespace_option}")
     secret = kubernetes_secret["data"]
 
     abort "Error: key '#{key}' not found in secret '#{shared_secret}'" unless secret
@@ -1788,11 +1805,15 @@ end
 
 def secrets_set
   if ARGV.length < 2
-    puts "Usage: k secrets:set <secret-name> <key>=<value> [<key2>=<value2> ...]"
+    puts "Usage: k secrets:set [namespace:]<secret-name> <key>=<value> [<key2>=<value2> ...]"
     exit
   end
 
-  shared_secret = ARGV.delete_at(0)
+  namespace, shared_secret = ARGV.delete_at(0)&.split(":")
+  unless shared_secret
+    shared_secret = namespace
+    namespace = "default"
+  end
   new_env = ARGV.map { |argument| argument.split("=", 2) }
 
   abort "Error: all environment variables must be in the form <key>=<value>" if new_env.any? { _1.length != 2 }
@@ -1803,12 +1824,12 @@ def secrets_set
   abort "Error: invalid environment variable names: #{bad_keys.join(', ')}" unless bad_keys.empty?
 
   in_argo_repo do
-    secret_path = "applications/shared-secrets/#{shared_secret}.yaml"
+    secret_path = "applications/shared-secrets/#{namespace_prefix(namespace)}#{shared_secret}.yaml"
     abort "No shared secret found at '#{secret_path}'" unless File.exist?(secret_path)
 
     require "base64"
 
-    original_secret = YAML.safe_load read_kubectl("get secret #{shared_secret} -o yaml")
+    original_secret = YAML.safe_load read_kubectl("get secret #{shared_secret} --namespace #{namespace} -o yaml")
     original_env = original_secret.fetch("data").transform_values(&Base64.method(:strict_decode64))
 
     new_env = original_env.merge(new_env)
@@ -1831,7 +1852,7 @@ def secrets_set
     end
     added_variables = new_env.keys - original_env.keys
 
-    commit_message = "shared-secrets: edited #{shared_secret}\n\n"
+    commit_message = "shared-secrets: edited #{shared_secret} in namespace #{namespace}\n\n"
     commit_message << "Changed: #{changed_variables.join(' ')}\n" unless changed_variables.empty?
     commit_message << "Added: #{added_variables.join(' ')}\n" unless added_variables.empty?
 
@@ -1843,23 +1864,29 @@ def secrets_set
 end
 
 def secrets_unset
-  if ARGV.length < 2
-    puts "Usage: k secrets:unset <secret-name> <key1> [<key2> ...]"
+  namespace, shared_secret = ARGV.delete_at(0)&.split(":")
+  unless shared_secret
+    shared_secret = namespace
+    namespace = "default"
+  end
+
+  keys = ARGV
+
+  unless shared_secret && keys
+    puts "Usage: k secrets:unset [namespace:]<secret-name> <key> [<key2> ...]"
     exit
   end
 
-  shared_secret = ARGV.delete_at(0)
-
   in_argo_repo do
-    secret_path = "applications/shared-secrets/#{shared_secret}.yaml"
+    secret_path = "applications/shared-secrets/#{namespace_prefix(namespace)}#{shared_secret}.yaml"
     abort "No shared secret found at '#{secret_path}'" unless File.exist?(secret_path)
 
     require "base64"
 
-    original_secret = YAML.safe_load read_kubectl("get secret #{shared_secret} -o yaml")
+    original_secret = YAML.safe_load read_kubectl("get secret #{shared_secret} --namespace #{namespace} -o yaml")
     original_env = original_secret.fetch("data").transform_values(&Base64.method(:strict_decode64))
 
-    new_env = original_env.except(*ARGV)
+    new_env = original_env.except(*keys)
 
     if new_env == original_env
       puts "No changes detected, skipping..."
@@ -1869,14 +1896,14 @@ def secrets_unset
     data = new_env.transform_values(&:to_s).transform_values(&Base64.method(:strict_encode64))
     original_secret["data"] = data
 
-    tmp_file = "/#{Dir.tmpdir}/#{shared_secret}.yaml"
+    tmp_file = "/#{Dir.tmpdir}/#{namespace_prefix(namespace)}#{shared_secret}.yaml"
     File.write(tmp_file, original_secret.to_yaml)
     kubeseal tmp_file, secret_path
     File.delete tmp_file
 
     deleted_variables = original_env.keys - new_env.keys
 
-    commit_message = "shared-secrets: edited #{shared_secret}\n\n"
+    commit_message = "shared-secrets: edited #{shared_secret} in namespace #{namespace}\n\n"
     commit_message << "Deleted: #{deleted_variables.join(' ')}\n"
 
     puts commit_message
@@ -1887,19 +1914,26 @@ def secrets_unset
 end
 
 def secrets_create
-  secret = ARGV.delete_at(0)
-  abort "Must pass name of the new secret, eg. k secrets:create <secret-name>" unless secret
+  namespace, shared_secret = ARGV.delete_at(0)&.split(":")
+  unless shared_secret
+    shared_secret = namespace
+    namespace = "default"
+  end
+
+  abort "Must pass name of the new secret, eg. k secrets:create [namespace:]<secret-name>" unless shared_secret
   abort "Missing $EDITOR environment variable, eg: export EDITOR='code --wait --new-window'" unless ENV.key?("EDITOR")
 
   require "base64"
 
   in_argo_repo do
-    secret_path = "applications/shared-secrets/#{secret}.yaml"
+    secret_path = "applications/shared-secrets/#{namespace_prefix(namespace)}#{shared_secret}.yaml"
+
     if File.exist?(secret_path)
-      abort "Error: A secret named '#{secret}' already exists, run 'k secrets:edit #{secret}' to edit it"
+      error_namespace_prefix = namespace == "default" ? "" : "#{namespace}:"
+      abort "Error: A secret named '#{shared_secret}' in namespace #{namespace} already exists, run 'k secrets:edit #{error_namespace_prefix}#{shared_secret}' to edit it"
     end
 
-    tmp_file = "/#{Dir.tmpdir}/#{secret}.yaml"
+    tmp_file = "/#{Dir.tmpdir}/#{namespace_prefix(namespace)}#{shared_secret}.yaml"
     File.write(
       tmp_file,
       <<~YAML,
@@ -1918,7 +1952,7 @@ def secrets_create
     secret_yaml = {
       "apiVersion" => "v1",
       "kind" => "Secret",
-      "metadata" => { "name" => secret },
+      "metadata" => { "name" => shared_secret, "namespace" => namespace },
       "type" => "opaque",
       "data" => data,
     }.to_yaml
@@ -1928,10 +1962,10 @@ def secrets_create
     File.delete tmp_file
 
     system_or_die "git add #{secret_path}"
-    system_or_die %(git commit -m "shared-secrets: add #{secret}" --quiet)
+    system_or_die %(git commit -m "shared-secrets: add #{shared_secret} in namespace #{namespace}" --quiet)
     safe_git_push
 
-    puts "Successfully created the secret '#{secret}'"
+    puts "Successfully created the secret '#{shared_secret}' in namespace #{namespace}"
   end
 end
 
@@ -2748,6 +2782,10 @@ def update
 end
 
 PRIVATE_METHODS_AFTER_COMMANDS = private_methods - PRIVATE_METHODS_BEFORE_COMMANDS
+
+def namespace_prefix(namespace)
+  namespace == "default" ? "" : "#{namespace}__"
+end
 
 def verify_inside_context_repository!
   context_repo = URI K_CONTEXT.fetch("repository").delete_suffix(".git").delete_suffix("/")


### PR DESCRIPTION
We had the need to manage secrets in multiple namespaces, this adds that functionality without changing the original interface. We did change one thing though and that was unset was not consistent with set, e.g. `unset` used "," where as `set` used spaces.

A concrete example is setting `SLACK_API_TOKEN` for alertmanager in the monitoring namespace, e.g  `k secrets:set monitoring:alertmanager SLACK_API_TOKEN=foo`.