### PR TITLE
support remote use

### DIFF
--- a/k
+++ b/k
@@ -5,6 +5,7 @@
 # KAIL_PATH - path to kail executable, defaults to "kail"
 # KUBESEAL_PATH - path to kubeseal executable, defaults to "kubeseal"
 # YQ_PATH - path to yq executable, defaults to "yq"
+# K_LISTEN_ON_ALL_INTERFACES - if set to "true", listen on 0.0.0.0 for local forwards
 
 require "date" # to protect against YAML bug present in certain psych versions: https://github.com/ruby/psych/pull/695
 require "yaml"
@@ -594,12 +595,19 @@ def kibana
   # kibana.k8s.elastic.co/name=mynewsdesk-funnel
 
   require "socket"
+  if ENV["K_LISTEN_ON_ALL_INTERFACES"] == "true"
+    kubectl_address_flag = " --address 0.0.0.0"
+    hostname = Socket.gethostname
+  else
+    kubectl_address_flag = ""
+    hostname = "localhost"
+  end
 
   5601.upto(5700) do |port|
     # If we can connect to the port another kibana is already active and we skip to the next port
     next if TCPSocket.new("127.0.0.1", port).close.nil? rescue false # rubocop:disable Style/RescueModifier
 
-    puts "Making kibana accessible at: http://localhost:#{port}/app/monitoring#/overview"
+    puts "Making kibana accessible at: http://#{hostname}:#{port}/app/monitoring#/overview"
     if system "which pbcopy > /dev/null 2>&1"
       puts "Storing kibana password in clipboard..."
       puts ""
@@ -612,7 +620,7 @@ def kibana
       puts "Login with username 'elastic' and paste the password '#{password}'"
     end
     puts ""
-    kubectl "port-forward service/#{application}-kb-http #{port}:5601"
+    kubectl "port-forward service/#{application}-kb-http #{port}:5601#{kubectl_address_flag}"
   end
 end
 

--- a/k_pg_proxy
+++ b/k_pg_proxy
@@ -11,6 +11,16 @@ PROXY_PORT = 10_000
 THREADS = 10
 CONTEXT = ARGV.first || `kubectl config current-context`.strip
 
+if ENV["K_LISTEN_ON_ALL_INTERFACES"] == "true"
+  BIND_HOST = "0.0.0.0"
+  KUBECTL_ADDRESS_FLAG = " --address 0.0.0.0"
+  HOSTNAME = Socket.gethostname
+else
+  BIND_HOST = "127.0.0.1"
+  KUBECTL_ADDRESS_FLAG = ""
+  HOSTNAME = "localhost"
+end
+
 def gray(string)
   $stdout.tty? ? "\e[0;90;49m#{string}\e[0m" : string
 end
@@ -240,7 +250,7 @@ def handle_connection(client_socket, connection_number)
 
   port_forward_port = PROXY_PORT + connection_number
   port_forward_pid = spawn(
-    "kubectl --context #{CONTEXT} port-forward #{primary_pod} #{port_forward_port}:5432",
+    "kubectl --context #{CONTEXT} port-forward #{primary_pod} #{port_forward_port}:5432#{KUBECTL_ADDRESS_FLAG}",
     err: File::NULL,
   )
   Process.detach(port_forward_pid)
@@ -294,12 +304,12 @@ ensure
   pg_socket&.close
 end
 
-puts "Listening for Postgres connections on localhost:#{PROXY_PORT}"
+puts "Listening for Postgres connections on #{HOSTNAME}:#{PROXY_PORT}"
 puts "Just pass the name of the kubernetes database and leave the rest to me!"
 puts ""
 puts "EXAMPLE:"
-puts "psql -h localhost -p #{PROXY_PORT} -d mynewsdesk-staging"
-server = TCPServer.new(PROXY_PORT)
+puts "psql -h #{HOSTNAME} -p #{PROXY_PORT} -d mynewsdesk-staging"
+server = TCPServer.new(BIND_HOST, PROXY_PORT)
 connection_number = 0
 
 loop do


### PR DESCRIPTION
if HOSTNAME is set (should be, on both mac and linux), that will be used for urls instead of localhost listen on all interfaces to allow remote access, for example for kibana