### PR TITLE
adds support for ssh style git url

### DIFF
--- a/k
+++ b/k
@@ -2828,11 +2828,15 @@ end
 
 def verify_inside_context_repository!
   context_repo = URI K_CONTEXT.fetch("repository").delete_suffix(".git").delete_suffix("/")
-  current_repo = URI `git remote get-url origin`.strip.delete_suffix(".git").delete_suffix("/")
+  current_repo = URI normalize_git_url(`git remote get-url origin`.strip.delete_suffix(".git").delete_suffix("/"))
 
   unless context_repo.path == current_repo.path
     abort "Error: this command must be run from a clone of the context repository (#{context_repo})"
   end
+end
+
+def normalize_git_url(url)
+  url.sub(/\A(?:ssh:\/\/)?git@([^:\/]+)[:\/](.+?)(?:\.git)?\z/i, 'https://\1/\2')
 end
 
 def system_or_die(command)


### PR DESCRIPTION
Running `k generate application <name>` while using ssh origin url crashes with `bad URI(is not URI?):`

Here is ChatGPT 5 explaining the regex:
```
This Ruby snippet is transforming a Git URL (usually in SSH form) into its HTTPS equivalent. Let’s break it down:

url.sub(
  /\A(?:ssh:\/\/)?git@([^:\/]+)[:\/](.+?)(?:\.git)?\z/i,
  'https://\1/\2'
)

1. url.sub(...)

sub replaces the first match of a regex in the string with the given replacement.

Here, it’s converting the url if it matches the SSH-style Git URL pattern.

2. The Regex Pattern

/\A(?:ssh:\/\/)?git@([^:\/]+)[:\/](.+?)(?:\.git)?\z/i

\A and \z: Match the start and end of the string (ensures the whole string is validated).

(?:ssh:\/\/)?: Non-capturing group, optional. Handles URLs like ssh://git@....

git@: Literal match (standard SSH Git prefix).

([^:\/]+): Captures the hostname (e.g., github.com or gitlab.com).

[:\/]: Matches either : (common in scp-like SSH URLs) or / (in some formats).

(.+?): Captures the repo path (e.g., user/repo).

(?:\.git)?: Non-capturing group, optional .git suffix.

i: Case-insensitive.

3. The Replacement String

'https://\1/\2'

\1: The first capture group → hostname.

\2: The second capture group → repo path.

Puts them into an HTTPS-style Git URL.

4. Example Conversions

Input:
"git@github.com:myorg/myrepo.git"
→ Output:
"https://github.com/myorg/myrepo"

Input:
"ssh://git@gitlab.com/myorg/myrepo"
→ Output:
"https://gitlab.com/myorg/myrepo"

Input:
"git@bitbucket.org:team/repo"
→ Output:
"https://bitbucket.org/team/repo"

✅ In short: This code takes SSH-based Git URLs (with or without ssh:// and .git) and normalizes them into clean HTTPS URLs.
```